### PR TITLE
Fix dist folder name in pattern-1/README.md 

### DIFF
--- a/pattern-1/bosh-release/README.md
+++ b/pattern-1/bosh-release/README.md
@@ -25,7 +25,7 @@ This deploys API Manager and Analytics on 2 seperate VMs, and starts MySQL as a 
 
 	    $ cd pivotal-cf-apim/bosh-release/
 	    
-4. Add the following binaries in to the `deployment` folder. Make sure to have exact versions as they are used in the scripts.
+4. Add the following binaries in to the `dist` folder. Make sure to have exact versions as they are used in the scripts.
 
 		jdk-8u144-linux-x64.tar.gz  
 		mysql-connector-java-5.1.24-bin.jar  


### PR DESCRIPTION
## Purpose
This pull request fixes the dist folder name in pattern-1/README.md file. Currently, it says that distributions need to be copied to the ```deployment``` folder but the deploy.sh file has been written to read those from the ```dist``` folder.