### PR TITLE
Parameterize API definition to be sent by the service bind call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 **/dev_releases/
 **/deployment/*
 **/dist/*
+**/.final_builds/*
+**/releases/*

--- a/service-broker/README.md
+++ b/service-broker/README.md
@@ -18,42 +18,42 @@ The following prerequisites are needed for the quick start:
  - [WSO2 API Manager v2.1.0](http://wso2.com/api-management/) distribution
  - [Ballerina v0.89](https://ballerinalang.org/) runtime distribution
 
-## Quick Start
+## Quick Start Guide
 
 The quick start provides steps for installing WSO2 API Manager service broker on PCF Dev.
 
-- Download and install PCF Dev by following [this](https://pivotal.io/platform/pcf-tutorials/getting-started-with-pivotal-cloud-foundry-dev/install-pcf-dev)
+- Download and install PCF Dev by following [this PCF tutorial](https://pivotal.io/platform/pcf-tutorials/getting-started-with-pivotal-cloud-foundry-dev/install-pcf-dev).
 
 - Start PCF Dev instance:
   
-  ```
+  ```bash
   $ cf dev start
   ```
 
-- Download Ballerina tools distribution from [ballerinalang.org](https://ballerinalang.org/) and add it's bin folder path to the PATH variable:
+- Download Ballerina tools distribution v0.89 from [ballerinalang.org](https://ballerinalang.org/) and add it's bin folder path to the PATH variable:
   
-  ````
+  ````bash
   $ export BAL_HOME="/path/to/ballerina/ballerina-tools-<version>/"
   $ export PATH=$BAL_HOME/bin:$PATH
   ````
 
 - Download WSO2 API Manager 2.1.0 distribution from [wso2.com](http://wso2.com/api-management/), extract it and start the server:
    
-  ````
+  ````bash
   $ unzip wso2am-2.1.0.zip
-  $ cd wso2am-2.1.0/
+  $ cd wso2am-2.1.0/ # refer this as WSO2_APIM_HOME
   $ bin/wso2server.sh start
   ````
 
 - Clone this git repository:
   
-  ````
+  ````bash
   $ git clone https://github.com/wso2/cf-service-broker-apim.git
   ````
 
-- Execute the following command to register a client in WSO2 API Manager for invoking its admin REST API:
+- Execute the following command to register an OAuth client application in WSO2 API Manager for invoking its admin API:
 
-  ````
+  ````bash
   $ curl -X POST -u <username>:<password> -H "Content-Type: application/json" -d '{
     "callbackUrl": "https://localhost/callback",
     "clientName": "wso2-apim-cf-service-broker",
@@ -66,7 +66,7 @@ The quick start provides steps for installing WSO2 API Manager service broker on
 
 - Expose following environment variables:
 
-  ````
+  ````bash
   $ export WSO2_APIM_TOKEN_ENDPOINT=https://<wso2-apim-hostname>:8243/token
   $ export WSO2_APIM_PUBLISHER_ENDPOINT=https://<wso2-apim-hostname>:9443/api/am/publisher
   $ export WSO2_APIM_PUBLISHER_UI_URL=https://<wso2-apim-hostname>:9443/publisher/
@@ -78,15 +78,15 @@ The quick start provides steps for installing WSO2 API Manager service broker on
 
 - Start the service broker API using Ballerina:
    
-  ````
+  ````bash
   $ cd /path/to/wso2-apim-service-broker/
   $ ballerina run service wso2apim/cf/servicebroker/
   ````
 
 - Find the IP address of the local machine and verify the catalog resource:
 
-  ````
-  $ curl -v http://<local-machine-ip>:9090/v2/catalog
+  ````bash
+  $ curl -v http://<service-broker-ip>:9090/v2/catalog
   ...
   > GET /v2/catalog HTTP/1.1
   > Host: localhost:9090
@@ -101,15 +101,15 @@ The quick start provides steps for installing WSO2 API Manager service broker on
   {"services":[{"id":"wso2-apim-service-broker","name":"wso2-apim","description":"WSO2 API-M service broker for Pivotal CloudFoundry","tags":["wso2","api"],"requires":[],"bindable":true,"metadata":{"provider":{"name":"WSO2"},"listing":{"imageUrl":"https://upload.wikimedia.org/wikipedia/en/5/56/WSO2_Software_Logo.png"}},"plan_updateable":false,"plans":[{"id":"1","name":"default","description":"Default plan without any costs","max_storage_tb":0,"metadata":{"costs":[],"bullets":[]}}]}]}
   ````
 
-- Create service broker using the following command:
+- Create WSO2 API-M service broker using the following command:
 
-  ````
-  $ cf create-service-broker wso2-apim <broker-service-api-username> <broker-service-api-password> http://<local-machine-ip>:9090
+  ````bash
+  $ cf create-service-broker wso2-apim <broker-service-api-username> <broker-service-api-password> http://<service-broker-ip>:9090 --space-scoped
   ````
   
 - Find WSO2 API-M service name and plan name using the following command:
 
-  ````
+  ````bash
   $ cf marketplace
   Getting services from marketplace in org pcfdev-org / space pcfdev-space as admin...
   OK
@@ -124,191 +124,134 @@ The quick start provides steps for installing WSO2 API Manager service broker on
   TIP:  Use 'cf marketplace -s SERVICE' to view descriptions of individual plans of a given service.
   ````
   
-- Create WSO2 API-M service instance using the following command:
+- Create a WSO2 API-M service instance using the following command:
  
-  ````
+  ````bash
   $ cf create-service wso2-apim default wso2-apim
   Creating service instance wso2-apim in org pcfdev-org / space pcfdev-space as admin...
   OK
   ````
 
-- Deploy sample spring music application on CF by following [this github repository](https://github.com/cloudfoundry-samples/spring-music).
-
-- List applications using the following command:
-
+- Clone following git repository to deploy a sample microservice on PCF:
+  ````bash
+  git clone https://github.com/wso2/msf4j
   ````
+
+- Build helloworld sample microservice using Maven:
+  ````bash
+  cd msf4j/samples/helloworld
+  mvn clean install
+  ````
+
+- Deploy helloworld sample microservice on PCF:
+  ````bash
+  cf push hello-service -p target/helloworld-2.5.3-SNAPSHOT.jar
+  ````
+
+- List PCF applications using the following command:
+
+  ````bash
   $ cf apps
   Getting apps in org pcfdev-org / space pcfdev-space as admin...
   OK
-    
-  name           requested state   instances   memory   disk   urls
-  spring-music   started           1/1         512M     512M   spring-music-doxastic-carucate.local.pcfdev.io
-  ````
-  
-- Bind WSO2 API-M service to an application using the following command:
 
+  name            requested state   instances   memory   disk   urls
+  hello-service   started           1/1         256M     512M   hello-service.local.pcfdev.io
   ````
-  parameters='{ "apiName":"foo", "apiVersion": "v1.0", "contextPath": "/foo", "serviceEndpoint": "http://foo.org", "serviceEndpointUsername": "admin", "serviceEndpointPassword": "admin"}'
-  cf bind-service <application-name> wso2-apim -c ${parameters}
-  Binding service wso2-apim to app spring-music in org pcfdev-org / space pcfdev-space as admin...
+
+- Create an API definition JSON file with the following content:
+  
+  ````json
+  {
+    "apiName": "HelloAPI",
+    "apiVersion": "v1.0",
+    "contextPath": "/hello",
+    "serviceEndpoint": "http://hello-service.local.pcfdev.io/hello",
+    "serviceEndpointUsername": "admin",
+    "serviceEndpointPassword": "admin",
+    "apiDefinition": {
+        "swagger": "2.0",
+        "paths": {
+            "/{name}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": ""
+                        }
+                    },
+                    "parameters": [
+                        {
+                            "name": "name",
+                            "in": "path",
+                            "allowMultiple": false,
+                            "required": true,
+                            "type": "string"
+                        }
+                    ]
+                }
+            }
+        },
+        "info": {
+            "title": "Hello API",
+            "version": "v1.0"
+        }
+    }
+  }
+  ````
+
+- Bind hello-service to WSO2 API-M service using the following command:
+
+  ````bash
+  cf bind-service hello-service wso2-apim -c api-definition.json
+  Binding service wso2-apim to app hello-service in org pcfdev-org / space pcfdev-space as admin...
   OK
-  TIP: Use 'cf restage spring-music' to ensure your env variable changes take effect
+  TIP: Use 'cf restage hello-service' to ensure your env variable changes take effect
   ````
 
-- Now login to WSO2 API-M store web application and verify the created API.
+- Now login to WSO2 API-M store and verify the created API.
 
-- Once verified, unbind WSO2 API-M service using the following command:
 
-  ````
-  $ cf unbind-service spring-music wso2-apim
-  ````
+## Quick Start Cleanup Guide
 
-## Installation Prerequisites
+- To cleanup the Quick Start POC first remove any subscriptions made for the above Hello API from the WSO2 API-M store.
 
-The following prerequisites are needed to install CloudFoundry service broker for WSO2 API Manager:
+- Unbind hello-service from WSO2 API-M service instance using the following command:
 
- - [Java Development Kit (JDK) 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
- - [WSO2 API Manager v2.1.0](http://wso2.com/api-management/) distribution
- - [Ballerina v0.89](https://ballerinalang.org/) tools distribution
- - A CloudFoundry environment
- - [Docker](http://docker.com/) runtime
-
-## Installation
-
-This section provides steps for installing WSO2 API Manager service broker on an existing CloudFoundry environment.
-
-- Download Ballerina tools distribution from [ballerinalang.org](https://ballerinalang.org/) and add it's bin folder path to the PATH variable:
-  
-  ````
-  $ export BAL_HOME="/path/to/ballerina/ballerina-tools-<version>/"
-  $ export PATH=$BAL_HOME/bin:$PATH
+  ````bash
+  $ cf unbind-service hello-service wso2-apim
+  Unbinding app hello-service from service wso2-apim in org pcfdev-org / space pcfdev-space as admin...
+  OK
   ````
 
-- Download WSO2 API Manager 2.1.0 distribution from [wso2.com](http://wso2.com/api-management/), extract it and start the server:
+- Delete WSO2 API-M service instance using the following command:
+
+  ````bash
+  $ cf delete-service wso2-apim
+
+  Really delete the service wso2-apim?> y
+  Deleting service wso2-apim in org pcfdev-org / space pcfdev-space as admin...
+  OK
+  ````
+
+- Remove the WSO2 API-M service broker using the following command:
+
+  ````bash
+  $ cf delete-service-broker wso2-apim
+
+  Really delete the service-broker wso2-apim?> y
+  Deleting service broker wso2-apim as admin...
+  OK
+  ````
+
+- Stop the PCF Dev instance using the following command:
+
+  ````bash
+  cf dev stop
+  ````
+
+- Stop the WSO2 API-M server using the following command:
    
-  ````
-  $ unzip wso2am-2.1.0.zip
-  $ cd wso2am-2.1.0/
-  $ bin/wso2server.sh start
-  ````
-
-- Clone this git repository and checkout the latest release tag:
-  
-  ````
-  $ git clone https://github.com/wso2/cf-service-broker-apim.git
-  $ git checkout tags/<latest-release-tag>
-  ````
-
-- Execute the following command to register a client in WSO2 API Manager for invoking its admin REST API:
-
-  ````
-  $ curl -X POST -u <username>:<password> -H "Content-Type: application/json" -d '{
-    "callbackUrl": "https://localhost/callback",
-    "clientName": "wso2-apim-cf-service-broker",
-    "tokenScope": "Production",
-    "owner": "admin",
-    "grantType": "password refresh_token",
-    "saasApp": true
-  }' http://<wso2-apim-hostname>:9763/client-registration/v0.11/register
-  ````
-
-- Build service broker API using the following command:
-  
-  ````
-  $ cd 
-  $ ballerina build service wso2apim/cf/servicebroker/
-  ````
-  
-- Create a Docker repository either in [Docker Hub](https://hub.docker.com/) or any other Docker registry that is not secured. 
-  Currently, [CloudFoundry does not support](https://docs.pivotal.io/pivotalcf/1-10/adminguide/docker.html) using Docker registries that require user credentials. Note down the repository name for the next step.
-
-- Create service broker API Docker image using the following command:
-
-  ````
-  $ docker_image=<repository>/wso2-apim-cf-service-broker-api:1.0.0
-  $ ballerina docker servicebroker.bsz -t ${docker_image} -y 
-  ````
-  
-- Push service broker API Docker image to a Docker registry:
-
-  ````
-  $ docker push ${docker_image}
-  ````
-  
-- Push service broker API to CloudFoundry as an application:
-
-  ````
-  $ cf push wso2-apim-cf-service-broker-api --docker-image ${docker_image}
-  ````
-
-- Login to PCF Dev web console and add following environment variables to the above service broker API application:
-
-  ````
-  WSO2_APIM_TOKEN_ENDPOINT=https://<wso2-apim-hostname>:8243/token
-  WSO2_APIM_PUBLISHER_ENDPOINT=https://<wso2-apim-hostname>:9443/api/am/publisher
-  WSO2_APIM_PUBLISHER_UI_URL=https://<wso2-apim-hostname>:9443/publisher/
-  WSO2_APIM_CLIENT_ID=<client-id-generated-above>
-  WSO2_APIM_CLIENT_SECRET=<client-secret-generated-above>
-  WSO2_APIM_USERNAME=admin
-  WSO2_APIM_PASSWORD=admin
-  ````
-
-- Create service broker using the following command:
-
-  ````
-  $ cf create-service-broker wso2-apim <broker-service-api-username> <broker-service-api-password> <broker-service-api-url>
-  ````
-  
-- Find WSO2 API-M service name and plan name using the following command:
-
-  ````
-  $ cf marketplace
-  Getting services from marketplace in org pcfdev-org / space pcfdev-space as admin...
-  OK
-  
-  service                     plans             description
-  wso2-apim                   default           WSO2 API-M service broker for Pivotal CloudFoundry
-  local-volume                free-local-disk   Local service docs: https://github.com/cloudfoundry-incubator/local-volume-release/
-  p-mysql                     512mb, 1gb        MySQL databases on demand
-  p-rabbitmq                  standard          RabbitMQ is a robust and scalable high-performance multi-protocol messaging broker.
-  p-redis                     shared-vm         Redis service to provide a key-value store
-  
-  TIP:  Use 'cf marketplace -s SERVICE' to view descriptions of individual plans of a given service.
-  ````
-  
-- Create WSO2 API-M service instance using the following command:
- 
-  ````
-  $ cf create-service wso2-apim default wso2-apim
-  Creating service instance wso2-apim in org pcfdev-org / space pcfdev-space as admin...
-  OK
-  ````
-  
-- List applications using the following command:
-
-  ````
-  $ cf apps
-  Getting apps in org pcfdev-org / space pcfdev-space as admin...
-  OK
-    
-  name           requested state   instances   memory   disk   urls
-  spring-music   started           1/1         512M     512M   spring-music-doxastic-carucate.local.pcfdev.io
-  ````
-  
-- Bind WSO2 API-M service to an application using the following command:
-
-  ````
-  parameters='{ "apiName":"foo", "apiVersion": "v1.0", "contextPath": "/foo", "serviceEndpoint": "http://foo.org", "serviceEndpointUsername": "admin", "serviceEndpointPassword": "admin"}'
-  cf bind-service <application-name> wso2-apim -c ${parameters}
-  Binding service wso2-apim to app spring-music in org pcfdev-org / space pcfdev-space as admin...
-  OK
-  TIP: Use 'cf restage spring-music' to ensure your env variable changes take effect
-  ````
-
-- Now login to WSO2 API-M store web application and verify the created API.
-
-- Once verified, unbind WSO2 API-M service using the following command:
-
-  ````
-  $ cf unbind-service spring-music wso2-apim
+  ````bash
+  cd $WSO2_APIM_HOME/bin
+  ./wso2server.sh stop
   ````

--- a/service-broker/wso2apim/cf/servicebroker/service-broker-api.bal
+++ b/service-broker/wso2apim/cf/servicebroker/service-broker-api.bal
@@ -136,13 +136,19 @@ service<http> serviceBroker {
         }
         string serviceEndpointPassword = strings:valueOf(parameters.serviceEndpointPassword);
 
+        if(parameters.apiDefinition == null) {
+            responseMessage = createErrorResponse("API definition not found in parameters");
+            reply responseMessage;
+        }
+        json apiDef = parameters.apiDefinition;
+
         string token = wso2apimclient:getAccessToken(tokenEndpoint, username, password, clientId, clientSecret);
         string reference = createReference(bindingId);
 
         string apiId = "";
         string error = "";
         apiId, error = wso2apimclient:createApi(publisherEndpoint, token, apiName, apiVersion, contextPath, serviceEndpoint,
-                                 serviceEndpointUsername, serviceEndpointPassword, reference);
+                                 serviceEndpointUsername, serviceEndpointPassword, reference, apiDef);
         if (apiId == "") {
             json payload = { "error": error };
             http:setStatusCode(responseMessage, 400);

--- a/service-broker/wso2apim/cf/servicebroker/service-broker-api.bal
+++ b/service-broker/wso2apim/cf/servicebroker/service-broker-api.bal
@@ -93,50 +93,50 @@ service<http> serviceBroker {
         json parameters = request.parameters;
 
         message responseMessage = {};
-        if(parameters == null) {
+        if (parameters == null) {
             http:setStatusCode(responseMessage, 400);
             json error = { "error": "Parameters not found in request message" };
             messages:setJsonPayload(responseMessage, error);
             reply responseMessage;
         }
 
-        if(parameters.apiName == null) {
+        if (parameters.apiName == null) {
             responseMessage = createErrorResponse("API name not found in parameters");
             reply responseMessage;
         }
         string apiName = strings:valueOf(parameters.apiName);
 
-        if(parameters.apiVersion == null) {
+        if (parameters.apiVersion == null) {
             responseMessage = createErrorResponse("API version not found in parameters");
             reply responseMessage;
         }
         string apiVersion = strings:valueOf(parameters.apiVersion);
 
-        if(parameters.contextPath == null) {
+        if (parameters.contextPath == null) {
             responseMessage = createErrorResponse("Context path not found in parameters");
             reply responseMessage;
         }
         string contextPath = strings:valueOf(parameters.contextPath);
 
-        if(parameters.serviceEndpoint == null) {
+        if (parameters.serviceEndpoint == null) {
             responseMessage = createErrorResponse("Service endpoint not found in parameters");
             reply responseMessage;
         }
         string serviceEndpoint = strings:valueOf(parameters.serviceEndpoint);
 
-        if(parameters.serviceEndpointUsername == null) {
+        if (parameters.serviceEndpointUsername == null) {
             responseMessage = createErrorResponse("Service endpoint username not found in parameters");
             reply responseMessage;
         }
         string serviceEndpointUsername = strings:valueOf(parameters.serviceEndpointUsername);
 
-        if(parameters.serviceEndpointPassword == null) {
+        if (parameters.serviceEndpointPassword == null) {
             responseMessage = createErrorResponse("Service endpoint password not found in parameters");
             reply responseMessage;
         }
         string serviceEndpointPassword = strings:valueOf(parameters.serviceEndpointPassword);
 
-        if(parameters.apiDefinition == null) {
+        if (parameters.apiDefinition == null) {
             responseMessage = createErrorResponse("API definition not found in parameters");
             reply responseMessage;
         }
@@ -158,7 +158,7 @@ service<http> serviceBroker {
 
         boolean success;
         success, error = wso2apimclient:publishApi(publisherEndpoint, token, apiId, apiName);
-        if(!success) {
+        if (!success) {
             json payload = { "error": error };
             http:setStatusCode(responseMessage, 400);
             messages:setJsonPayload(responseMessage, payload);
@@ -187,13 +187,13 @@ service<http> serviceBroker {
 
         message responseMessage = {};
         apiId, apiName, error = wso2apimclient:getApiIdNameByReference(publisherEndpoint, token, reference);
-        if(apiId == "") {
+        if (apiId == "") {
             json payload = { "error": "Could not find API with binding id " + bindingId };
             http:setStatusCode(responseMessage, 404);
             messages:setJsonPayload(responseMessage, payload);
             reply responseMessage;
         }
-        if(error != "") {
+        if (error != "") {
             json payload = { "error": error };
             http:setStatusCode(responseMessage, 400);
             messages:setJsonPayload(responseMessage, payload);
@@ -202,7 +202,7 @@ service<http> serviceBroker {
 
         boolean success = false;
         success, error = wso2apimclient:deleteApi(publisherEndpoint, token, apiId, apiName);
-        if(!success) {
+        if (!success) {
             json payload = { "error": error };
             http:setStatusCode(responseMessage, 400);
             messages:setJsonPayload(responseMessage, payload);

--- a/service-broker/wso2apim/publisher/api/client/publisher-api-client.bal
+++ b/service-broker/wso2apim/publisher/api/client/publisher-api-client.bal
@@ -35,15 +35,13 @@ function getAccessToken (string tokenEndpoint, string username, string password,
 
 function createApi (string publisherEndpoint, string token, string apiName,
                     string apiVersion, string contextPath, string serviceEndpoint,
-                    string serviceUsername, string servicePassword, string reference) (string apiId, string error) {
+                    string serviceUsername, string servicePassword, string reference, json apiDef) (string apiId, string error) {
 
     system:println("Creating API " + apiName + "...");
 
     message requestMessage = {};
     messages:setHeader(requestMessage, "Content-Type", "application/json");
     messages:setHeader(requestMessage, "Authorization", "Bearer " + token);
-
-    json apiDef = {"paths":{"/order":{"post":{"x-auth-type":"Application & Application User", "x-throttling-tier":"Unlimited", "description":"Create a new Order", "parameters":[{"schema":{"$ref":"#/definitions/Order"}, "description":"Order object that needs to be added", "name":"body", "required":true, "in":"body"}], "responses":{"201":{"headers":{"Location":{"description":"The URL of the newly created resource.", "type":"string"}}, "schema":{"$ref":"#/definitions/Order"}, "description":"Created."}}}}, "/menu":{"get":{"x-auth-type":"Application & Application User", "x-throttling-tier":"Unlimited", "description":"Return a list of available menu items", "parameters":[], "responses":{"200":{"headers":{}, "schema":{"title":"Menu", "properties":{"list":{"items":{"$ref":"#/definitions/MenuItem"}, "type":"array"}}, "type":"object"}, "description":"OK."}}}}}, "schemes":["https"], "produces":["application/json"], "swagger":"2.0", "definitions":{"MenuItem":{"title":"Pizza menu Item", "properties":{"price":{"type":"string"}, "description":{"type":"string"}, "name":{"type":"string"}, "image":{"type":"string"}}, "required":["name"]}, "Order":{"title":"Pizza Order", "properties":{"customerName":{"type":"string"}, "delivered":{"type":"boolean"}, "address":{"type":"string"}, "pizzaType":{"type":"string"}, "creditCardNumber":{"type":"string"}, "quantity":{"type":"number"}, "orderId":{"type":"integer"}}, "required":["orderId"]}}, "consumes":["application/json"], "info":{"title":"PizzaShackAPI", "description":"This document describe a RESTFul API for Pizza Shack online pizza delivery store.\\n", "license":{"name":"Apache 2.0", "url":"http://www.apache.org/licenses/LICENSE-2.0.html"}, "contact":{"email":"architecture@pizzashack.com", "name":"John Doe", "url":"http://www.pizzashack.com"}, "version":"1.0.0"}};
 
     json payload = {
                        "name":apiName,


### PR DESCRIPTION
This pull request has following improvements:
- Parameterize API definition to be sent by the service bind call.
- Add .final_builds/ and releases/ to .gitignore file.
- Update service broker README.md file with steps for trying out the service broker with a sample microservice.