### PR TITLE
Replace Oracle JDK with Open JDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,11 @@
 **/releases/*
 
 **/tile/product/
+**/tile/cache/
+!**/tile/product/.gitkeep
 **/tile/release/
 **/tile/routing-0.178.0.tgz
-**/tile/wso2am-2.6.0.tgz
+**/tile/wso2am-2.6.0*
 **/tile/tile-history.yml
+
+**/bosh-release/wso2*

--- a/.gitignore
+++ b/.gitignore
@@ -12,11 +12,12 @@
 **/dev_releases/
 **/deployment/*
 **/dist/*
+!**/dist/.gitkeep
 **/.final_builds/*
 **/releases/*
 
 **/tile/product/
 **/tile/release/
 **/tile/routing-0.178.0.tgz
-**/tile/wso2am-2.1.0.tgz
+**/tile/wso2am-2.6.0.tgz
 **/tile/tile-history.yml

--- a/pattern-1/bosh-release/README.md
+++ b/pattern-1/bosh-release/README.md
@@ -1,6 +1,6 @@
 # BOSH release for WSO2 API Manager deployment <br>pattern 1
 
-This repository includes a BOSH release that can be used to deploy WSO2 API Manager 2.1.0 deployment pattern 1
+This repository includes a BOSH release that can be used to deploy WSO2 API Manager 2.6.0 deployment pattern 1
 configured to use a MySQL database on BOSH Director.
 
 ## Create and deploy the BOSH Release in BOSH Lite
@@ -21,7 +21,7 @@ Install the following software:
     ```
     git clone https://github.com/wso2/pivotal-cf-apim.git
     ```
-    
+
 2. Navigate to `pivotal-cf-apim/pattern-1/bosh-release` directory.
 
 3. Add the following software distributions to the `dist` folder.
@@ -38,22 +38,22 @@ Install the following software:
    ```
    ./deploy.sh
    ```
-   Executing this script will setup MySQL, BOSH environment and will deploy WSO2 API Manager 2.1.0 deployment pattern 1 on BOSH director.
+   Executing this script will setup MySQL, BOSH environment and will deploy WSO2 API Manager 2.6.0 deployment pattern 1 on BOSH director.
 
 5. Find the IP addresses of created VMs via the BOSH CLI and access the WSO2 API Manager Publisher, Store and Management Console via a web browser.
     ```
     bosh -e vbox vms
     ...
-    
+
     Deployment 'wso2apim'
-    
+
     Instance                                                 Process State  AZ  IPs          VM CID                                VM Type  
     wso2apim_1/da718160-7588-4594-a6fb-71aa73845a1b          running        -   10.244.15.2  45149778-a699-4030-7374-dd9613f43901  wso2apim-resource-pool  
     wso2apim_2/25e4cbc3-061d-48c9-ba33-5d71edb74f29          running        -   10.244.15.3  cb0408a3-50ed-4d7d-66ed-2ef50c1a2dd0  wso2apim-resource-pool  
     wso2apim_analytics/04d6fb22-82bd-42d6-9e93-a42ad5f6ec8d  running        -   10.244.15.4  f8bf7609-eeab-4700-4c08-70bf0edfd18a  wso2apim_analytics-resource-pool  
-    
+
     3 vms
-    
+
     Succeeded
     ...
     ```

--- a/pattern-1/bosh-release/config/blobs.yml
+++ b/pattern-1/bosh-release/config/blobs.yml
@@ -1,16 +1,16 @@
-mysqldriver/mysql-connector-java-5.1.46-bin.jar:
-  size: 1004840
-  object_id: dbd07016-6dd6-4434-4550-67c1b11f4bdd
-  sha: 0a22bced42a2f076aaa17feee67fc6b998cfd4f9
+mysqldriver/mysql-connector-java-5.1.45-bin.jar:
+  size: 999810
+  object_id: 6b03eea8-c9b6-442a-68fd-d79c109fac8f
+  sha: 6223be933fbc8d81f819aacad0ce09346d5911c4
 oraclejdk/jdk-8u144-linux-x64.tar.gz:
   size: 185515842
-  object_id: 6dca9345-0c3e-4f29-6e56-fe217239cb79
+  object_id: 17ca1894-862e-4299-5255-20053e1cf57d
   sha: d4c4f02908d39827393dd77f9eb8da348363efda
 wso2am/wso2am-2.6.0.zip:
-  size: 435412214
-  object_id: c96d124e-d1a1-4682-4256-1f080e0cb003
-  sha: c061798665e35dc6c87902ac11cdc6924fb825ad
+  size: 444084271
+  object_id: 23260102-6fb0-4371-46ab-62db99ab231d
+  sha: c31c9c9dd87a6a6065779c28c6908bd76e4914f3
 wso2am_analytics/wso2am-analytics-2.6.0.zip:
-  size: 173195394
-  object_id: 18b52a4d-f894-486f-5a90-18003401018d
-  sha: 7f26e89d6d71753e8651c952653e1df53deff2be
+  size: 180832478
+  object_id: 4c3b2ffd-70eb-476f-4526-38e9c12414d7
+  sha: b60e811d5abb500f5793cc73012f1040bc2a88c0

--- a/pattern-1/bosh-release/config/blobs.yml
+++ b/pattern-1/bosh-release/config/blobs.yml
@@ -1,16 +1,16 @@
 mysqldriver/mysql-connector-java-5.1.45-bin.jar:
   size: 999810
-  object_id: 6b03eea8-c9b6-442a-68fd-d79c109fac8f
+  object_id: 0b8666ee-8cd8-476a-78be-22a24704cef3
   sha: 6223be933fbc8d81f819aacad0ce09346d5911c4
-oraclejdk/jdk-8u144-linux-x64.tar.gz:
-  size: 185515842
-  object_id: 17ca1894-862e-4299-5255-20053e1cf57d
-  sha: d4c4f02908d39827393dd77f9eb8da348363efda
+openjdk/jdk-8u202-ea-bin-b03-linux-x64-07_nov_2018.tar.gz:
+  size: 139097684
+  object_id: c9137abc-b5d3-436d-45ff-46bb40d9dcc5
+  sha: 43df5d55fff80327cc83680cda6170f33308883c
 wso2am/wso2am-2.6.0.zip:
   size: 444084271
-  object_id: 23260102-6fb0-4371-46ab-62db99ab231d
+  object_id: bc5bf851-58e3-469c-4c7e-cd5fb5f46cdd
   sha: c31c9c9dd87a6a6065779c28c6908bd76e4914f3
 wso2am_analytics/wso2am-analytics-2.6.0.zip:
   size: 180832478
-  object_id: 4c3b2ffd-70eb-476f-4526-38e9c12414d7
+  object_id: 8c5d048d-62fe-4e3d-6596-c5104fec4349
   sha: b60e811d5abb500f5793cc73012f1040bc2a88c0

--- a/pattern-1/bosh-release/create.sh
+++ b/pattern-1/bosh-release/create.sh
@@ -29,7 +29,7 @@ set -e
 : ${wso2_product_distribution:=${wso2_product_pack_identifier}"*.zip"}
 : ${wso2_product_analytics_pack_identifier:="${wso2_product}-analytics-${wso2_product_version}"}
 : ${wso2_product_analytics_distribution:=${wso2_product_analytics_pack_identifier}"*.zip"}
-: ${jdk_distribution:="jdk-8u*-linux-x64.tar.gz"}
+: ${jdk_distribution:="jdk-8u*linux-x64*.tar.gz"}
 : ${mysql_driver:="mysql-connector-java-5.1.*-bin.jar"}
 
 # repository folder structure variables
@@ -150,7 +150,7 @@ cd ..
 # add the locally available WSO2 product distribution(s) and dependencies as blobs to the BOSH Director
 echo "---> Adding blobs..."
 
-bosh -e vbox add-blob ${distributions}/${jdk_distribution} oraclejdk/${jdk_distribution}
+bosh -e vbox add-blob ${distributions}/${jdk_distribution} openjdk/${jdk_distribution}
 bosh -e vbox add-blob ${distributions}/${mysql_driver} mysqldriver/${mysql_driver}
 bosh -e vbox add-blob ${distributions}/${wso2_product_pack_identifier}.zip ${wso2_product}/${wso2_product_pack_identifier}.zip
 bosh -e vbox add-blob ${distributions}/${wso2_product_analytics_pack_identifier}.zip ${wso2_product}_analytics/${wso2_product_analytics_pack_identifier}.zip

--- a/pattern-1/bosh-release/deploy.sh
+++ b/pattern-1/bosh-release/deploy.sh
@@ -26,7 +26,7 @@ os_name=`uname`
 
 # deployment artifacts and versions
 export wso2_product="wso2am"
-export wso2_product_version="2.1.0"
+export wso2_product_version="2.6.0"
 export wso2_product_pack_identifier="${wso2_product}-${wso2_product_version}"
 export wso2_product_distribution=${wso2_product_pack_identifier}"*.zip"
 export wso2_product_analytics_pack_identifier="${wso2_product}-analytics-${wso2_product_version}"

--- a/pattern-1/bosh-release/deploy.sh
+++ b/pattern-1/bosh-release/deploy.sh
@@ -31,7 +31,7 @@ export wso2_product_pack_identifier="${wso2_product}-${wso2_product_version}"
 export wso2_product_distribution=${wso2_product_pack_identifier}"*.zip"
 export wso2_product_analytics_pack_identifier="${wso2_product}-analytics-${wso2_product_version}"
 export wso2_product_analytics_distribution=${wso2_product_analytics_pack_identifier}"*.zip"
-export jdk_distribution="jdk-8u*-linux-x64.tar.gz"
+export jdk_distribution="jdk-8u*linux-x64*.tar.gz"
 export mysql_driver="mysql-connector-java-5.1.*-bin.jar"
 
 # repository folder structure variables

--- a/pattern-1/bosh-release/jobs/wso2apim_1/spec
+++ b/pattern-1/bosh-release/jobs/wso2apim_1/spec
@@ -14,7 +14,7 @@ templates:
   jaggeryapps/publisher/site.json: jaggeryapps/publisher/site.json
 
 packages:
-- oraclejdk
+- openjdk
 - mysqldriver
 - wso2apim
 - common

--- a/pattern-1/bosh-release/jobs/wso2apim_1/templates/ctl.erb
+++ b/pattern-1/bosh-release/jobs/wso2apim_1/templates/ctl.erb
@@ -35,7 +35,7 @@ chown -R vcap:vcap ${run_dir} ${log_dir}
 mkdir -p /var/vcap/store/wso2apim/data
 export WSO2_APIM_DATA_DIR=/var/vcap/store/wso2apim/data/wso2apim
 
-export JDK_HOME=/var/vcap/packages/oraclejdk/
+export JDK_HOME=/var/vcap/packages/openjdk/
 export WSO2_APIM_PKG_HOME=/var/vcap/packages/wso2apim/
 export WSO2_APIM_SERVER_PACKAGE=/var/vcap/packages/wso2apim/
 
@@ -83,7 +83,7 @@ case $1 in
     pushd ${JDK_HOME}
     archive=`ls jdk*gz`
     tar -zxvf $archive
-    export JAVA_HOME=`pwd`/jdk1.8.0_144
+    export JAVA_HOME=`pwd`/jdk1.8.0_202
     export JAVA_BINARY=${JAVA_HOME}/bin/java
 
     log_debug "JAVA_HOME: ${JAVA_HOME}"

--- a/pattern-1/bosh-release/jobs/wso2apim_2/spec
+++ b/pattern-1/bosh-release/jobs/wso2apim_2/spec
@@ -10,7 +10,7 @@ templates:
   config/user-mgt.xml: config/user-mgt.xml
 
 packages:
-- oraclejdk
+- openjdk
 - mysqldriver
 - wso2apim
 - common

--- a/pattern-1/bosh-release/jobs/wso2apim_2/templates/config/api-manager.xml
+++ b/pattern-1/bosh-release/jobs/wso2apim_2/templates/config/api-manager.xml
@@ -136,7 +136,7 @@
 
              Ex - Multiple Receiver Groups with two receivers each
              {tcp://localhost:7612/,tcp://localhost:7613},{tcp://localhost:7712/,tcp://localhost:7713/} -->
-        <DASServerURL>{tcp://<%=properties.wso2apim.analytics.hostname %>:7612}</DASServerURL>
+        <DASServerURL>{tcp://<%= properties.wso2apim.analytics.hostname %>:7612}</DASServerURL>
         <!--DASAuthServerURL>{ssl://localhost:7712}</DASAuthServerURL-->
         <!-- Administrator username to login to the remote DAS server. -->
         <DASUsername>${admin.username}</DASUsername>
@@ -147,7 +147,7 @@
         <StatsProviderImpl>org.wso2.carbon.apimgt.usage.client.impl.APIUsageStatisticsRdbmsClientImpl</StatsProviderImpl>
 
         <!-- DAS REST API configuration -->
-        <DASRestApiURL>https://<%=properties.wso2apim.analytics.hostname %>:9444</DASRestApiURL>
+        <DASRestApiURL>https://<%= properties.wso2apim.analytics.hostname %>:9444</DASRestApiURL>
         <DASRestApiUsername>${admin.username}</DASRestApiUsername>
         <DASRestApiPassword>${admin.password}</DASRestApiPassword>
 
@@ -228,7 +228,7 @@
             <MaxIdle>100</MaxIdle>
             <InitIdleCapacity>50</InitIdleCapacity>
         </ConnectionPool-->
-        <!-- Specifies the implementation to be used for KeyValidationHandler. Steps for validating a token can be controlled by plugging in a 
+        <!-- Specifies the implementation to be used for KeyValidationHandler. Steps for validating a token can be controlled by plugging in a
              custom KeyValidation Handler -->
         <KeyValidationHandlerClassName>org.wso2.carbon.apimgt.keymgt.handlers.DefaultKeyValidationHandler</KeyValidationHandlerClassName>
     </APIKeyValidator>
@@ -330,7 +330,7 @@
     <!-- Status observers can be registered against the API Publisher to listen for
          API status update events. Each observer must implement the APIStatusObserver
          interface. Multiple observers can be engaged if necessary and in such situations
-         they will be notified in the order they are defined here. 
+         they will be notified in the order they are defined here.
          This configuration is unused from API Manager version 1.10.0 -->
     <!--StatusObservers>
         <Observer>org.wso2.carbon.apimgt.impl.observers.SimpleLoggingObserver</Observer>
@@ -397,7 +397,7 @@
              It is false by default and if you set it to true then make sure that the Access-Control-Allow-Origin header does not contain the wildcard (*) -->
         <Access-Control-Allow-Credentials>false</Access-Control-Allow-Credentials>
     </CORSConfiguration>
-    
+
     <!-- This property is there to configure velocity log output into existing Log4j carbon Logger.
          You can enable this and set preferable Logger name. -->
     <!-- VelocityLogger>VELOCITY</VelocityLogger -->
@@ -649,10 +649,10 @@
         <EnableJWTClaimConditions>false</EnableJWTClaimConditions>
         <EnableQueryParamConditions>false</EnableQueryParamConditions>
     </ThrottlingConfigurations>
-    
+
     <WorkflowConfigurations>
         <Enabled>false</Enabled>
-    	<ServerUrl>https://localhost:9445/bpmn</ServerUrl>   		
+    	<ServerUrl>https://localhost:9445/bpmn</ServerUrl>
     	<ServerUser>${admin.username}</ServerUser>
     	<ServerPassword>${admin.password}</ServerPassword>
     	<WorkflowCallbackAPI>https://localhost:${mgt.transport.https.port}/api/am/publisher/v0.11/workflows/update-workflow-status</WorkflowCallbackAPI>

--- a/pattern-1/bosh-release/jobs/wso2apim_2/templates/config/log4j.properties
+++ b/pattern-1/bosh-release/jobs/wso2apim_2/templates/config/log4j.properties
@@ -187,7 +187,7 @@ log4j.appender.DAS_AGENT.layout=org.wso2.carbon.analytics.shared.data.agents.log
 log4j.appender.DAS_AGENT.columnList=%D,%S,%A,%d,%c,%p,%m,%H,%I,%Stacktrace
 log4j.appender.DAS_AGENT.userName=admin
 log4j.appender.DAS_AGENT.password=admin
-log4j.appender.DAS_AGENT.url=tcp://<%=properties.wso2apim.analytics.hostname %>:7612
+log4j.appender.DAS_AGENT.url=tcp://<%= properties.wso2apim.analytics.hostname %>:7612
 log4j.appender.DAS_AGENT.maxTolerableConsecutiveFailure=5
 log4j.appender.DAS_AGENT.streamDef=loganalyzer:1.0.0
 log4j.logger.trace.messages=TRACE,CARBON_TRACE_LOGFILE

--- a/pattern-1/bosh-release/jobs/wso2apim_2/templates/ctl.erb
+++ b/pattern-1/bosh-release/jobs/wso2apim_2/templates/ctl.erb
@@ -35,7 +35,7 @@ chown -R vcap:vcap ${run_dir} ${log_dir}
 mkdir -p /var/vcap/store/wso2apim/data
 export WSO2_APIM_DATA_DIR=/var/vcap/store/wso2apim/data/wso2apim
 
-export JDK_HOME=/var/vcap/packages/oraclejdk/
+export JDK_HOME=/var/vcap/packages/openjdk/
 export WSO2_APIM_PKG_HOME=/var/vcap/packages/wso2apim/
 export WSO2_APIM_SERVER_PACKAGE=/var/vcap/packages/wso2apim/
 
@@ -66,7 +66,7 @@ case $1 in
     pushd ${JDK_HOME}
     archive=`ls jdk*gz`
     tar -zxvf $archive
-    export JAVA_HOME=`pwd`/jdk1.8.0_144
+    export JAVA_HOME=`pwd`/jdk1.8.0_202
     export JAVA_BINARY=${JAVA_HOME}/bin/java
 
     log_debug "JAVA_HOME: ${JAVA_HOME}"
@@ -82,7 +82,7 @@ case $1 in
     cp -r ${job_dir}/config/* ${WSO2_APIM_HOME}/repository/conf/
 
     # Here add any libraries your application needs:
-    cp /var/vcap/packages/mysqldriver/* ${WSO2_APIM_HOME}/repository/components/lib/ 
+    cp /var/vcap/packages/mysqldriver/* ${WSO2_APIM_HOME}/repository/components/lib/
 
     $WSO2_APIM_HOME/bin/wso2server.sh start
 

--- a/pattern-1/bosh-release/jobs/wso2apim_analytics/spec
+++ b/pattern-1/bosh-release/jobs/wso2apim_analytics/spec
@@ -5,7 +5,7 @@ templates:
   config/deployment.yaml: config/deployment.yaml
 
 packages:
-- oraclejdk
+- openjdk
 - mysqldriver
 - wso2apim_analytics
 - common

--- a/pattern-1/bosh-release/jobs/wso2apim_analytics/templates/ctl.erb
+++ b/pattern-1/bosh-release/jobs/wso2apim_analytics/templates/ctl.erb
@@ -35,7 +35,7 @@ chown -R vcap:vcap ${run_dir} ${log_dir}
 mkdir -p /var/vcap/store/wso2apim_analytics/data
 export WSO2_APIM_ANALYTICS_DATA_DIR=/var/vcap/store/wso2apim_analytics/data/wso2apim_analytics
 
-export JDK_HOME=/var/vcap/packages/oraclejdk/
+export JDK_HOME=/var/vcap/packages/openjdk/
 export WSO2_APIM_ANALYTICS_PKG_HOME=/var/vcap/packages/wso2apim_analytics/
 export WSO2_APIM_ANALYTICS_SERVER_PACKAGE=/var/vcap/packages/wso2apim_analytics/
 
@@ -66,7 +66,7 @@ case $1 in
     pushd ${JDK_HOME}
     archive=`ls jdk*gz`
     tar -zxvf $archive
-    export JAVA_HOME=`pwd`/jdk1.8.0_144
+    export JAVA_HOME=`pwd`/jdk1.8.0_202
     export JAVA_BINARY=${JAVA_HOME}/bin/java
 
     log_debug "JAVA_HOME: ${JAVA_HOME}"

--- a/pattern-1/bosh-release/packages/openjdk/packaging
+++ b/pattern-1/bosh-release/packages/openjdk/packaging
@@ -1,12 +1,12 @@
 # abort script on any command that exit with a non zero value
 set -e
 
-archive=`echo oraclejdk/jdk-8u*-linux-x64.tar.gz`
+archive=`echo openjdk/jdk-8u*linux-x64*.tar.gz`
 
 if [[ -f $archive ]] ; then
-  echo "Oracle JDK archive found"
+  echo "Open JDK archive found"
 else
-  echo "Oracle JDK archive not found"
+  echo "Open JDK archive not found"
   exit 1
 fi
 

--- a/pattern-1/bosh-release/packages/openjdk/spec
+++ b/pattern-1/bosh-release/packages/openjdk/spec
@@ -1,0 +1,7 @@
+---
+name: openjdk
+
+dependencies: []
+
+files:
+- openjdk/jdk-8u*linux-x64*.tar.gz

--- a/pattern-1/bosh-release/packages/oraclejdk/spec
+++ b/pattern-1/bosh-release/packages/oraclejdk/spec
@@ -1,7 +1,0 @@
----
-name: oraclejdk
-
-dependencies: []
-
-files:
-- oraclejdk/jdk-8u*-linux-x64.tar.gz

--- a/pattern-1/bosh-release/wso2apim-manifest.yml
+++ b/pattern-1/bosh-release/wso2apim-manifest.yml
@@ -69,14 +69,6 @@ jobs:
   resource_pool: wso2apim-resource-pool
   templates:
   - name: wso2apim_2
-- instances: 1
-  name: nfs_server
-  networks:
-  - name: wso2apim_network
-    static_ips: [10.244.15.5]
-  resource_pool: wso2apim-resource-pool
-  templates:
-  - name: nfs_server
 meta:
   director_uuid: <%= `bosh target > /dev/null 2>&1 && bosh status --uuid` %>
 name: wso2apim

--- a/pattern-1/bosh-release/wso2apim-manifest.yml
+++ b/pattern-1/bosh-release/wso2apim-manifest.yml
@@ -69,6 +69,14 @@ jobs:
   resource_pool: wso2apim-resource-pool
   templates:
   - name: wso2apim_2
+- instances: 1
+  name: nfs_server
+  networks:
+  - name: wso2apim_network
+    static_ips: [10.244.15.5]
+  resource_pool: wso2apim-resource-pool
+  templates:
+  - name: nfs_server
 meta:
   director_uuid: <%= `bosh target > /dev/null 2>&1 && bosh status --uuid` %>
 name: wso2apim
@@ -106,7 +114,7 @@ properties:
       min_heap: 1024
 
 releases:
-- name: wso2apim-release
+- name: wso2am-release
   version: latest
 resource_pools:
 - cloud_properties: {}

--- a/pattern-1/tile/README.md
+++ b/pattern-1/tile/README.md
@@ -1,6 +1,6 @@
 # WSO2 API Manager Pivotal Cloud Foundry Tile
 
-This repository includes a Cloud Foundry Tile for deploying WSO2 API Manager 2.1.0 on BOSH via Pivotal Ops Manager. 
+This repository includes a Cloud Foundry Tile for deploying WSO2 API Manager 2.6.0 on BOSH via Pivotal Ops Manager. 
 
 ## Quick Start
 
@@ -14,7 +14,7 @@ This repository includes a Cloud Foundry Tile for deploying WSO2 API Manager 2.1
 2. Copy WSO2 API Manager BOSH release tar.gz file to the root folder of this tile project.
 
 3. Build the tile using the below command:
-   
+
    ```
    tile build --cache cache/
    ```

--- a/service-broker/README.md
+++ b/service-broker/README.md
@@ -15,7 +15,7 @@ The following prerequisites are needed for the quick start:
 
  - [PCF Dev v1.10](https://pivotal.io/platform/pcf-tutorials/getting-started-with-pivotal-cloud-foundry-dev/install-pcf-dev)
  - [Java Development Kit (JDK) 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
- - [WSO2 API Manager v2.1.0](http://wso2.com/api-management/) distribution
+ - [WSO2 API Manager v2.6.0](http://wso2.com/api-management/) distribution
  - [Ballerina v0.89](https://ballerinalang.org/) runtime distribution
 
 ## Quick Start Guide
@@ -25,28 +25,28 @@ The quick start provides steps for installing WSO2 API Manager service broker on
 - Download and install PCF Dev by following [this PCF tutorial](https://pivotal.io/platform/pcf-tutorials/getting-started-with-pivotal-cloud-foundry-dev/install-pcf-dev).
 
 - Start PCF Dev instance:
-  
+
   ```bash
   $ cf dev start
   ```
 
 - Download Ballerina tools distribution v0.89 from [ballerinalang.org](https://ballerinalang.org/) and add it's bin folder path to the PATH variable:
-  
+
   ````bash
   $ export BAL_HOME="/path/to/ballerina/ballerina-tools-<version>/"
   $ export PATH=$BAL_HOME/bin:$PATH
   ````
 
-- Download WSO2 API Manager 2.1.0 distribution from [wso2.com](http://wso2.com/api-management/), extract it and start the server:
-   
+- Download WSO2 API Manager 2.6.0 distribution from [wso2.com](http://wso2.com/api-management/), extract it and start the server:
+
   ````bash
-  $ unzip wso2am-2.1.0.zip
-  $ cd wso2am-2.1.0/ # refer this as WSO2_APIM_HOME
+  $ unzip wso2am-2.6.0.zip
+  $ cd wso2am-2.6.0/ # refer this as WSO2_APIM_HOME
   $ bin/wso2server.sh start
   ````
 
 - Clone this git repository:
-  
+
   ````bash
   $ git clone https://github.com/wso2/cf-service-broker-apim.git
   ````
@@ -77,7 +77,7 @@ The quick start provides steps for installing WSO2 API Manager service broker on
   ````
 
 - Start the service broker API using Ballerina:
-   
+
   ````bash
   $ cd /path/to/wso2-apim-service-broker/
   $ ballerina run service wso2apim/cf/servicebroker/
@@ -106,26 +106,26 @@ The quick start provides steps for installing WSO2 API Manager service broker on
   ````bash
   $ cf create-service-broker wso2-apim <broker-service-api-username> <broker-service-api-password> http://<service-broker-ip>:9090 --space-scoped
   ````
-  
+
 - Find WSO2 API-M service name and plan name using the following command:
 
   ````bash
   $ cf marketplace
   Getting services from marketplace in org pcfdev-org / space pcfdev-space as admin...
   OK
-  
+
   service                     plans             description
   wso2-apim                   default           WSO2 API-M service broker for Pivotal CloudFoundry
   local-volume                free-local-disk   Local service docs: https://github.com/cloudfoundry-incubator/local-volume-release/
   p-mysql                     512mb, 1gb        MySQL databases on demand
   p-rabbitmq                  standard          RabbitMQ is a robust and scalable high-performance multi-protocol messaging broker.
   p-redis                     shared-vm         Redis service to provide a key-value store
-  
+
   TIP:  Use 'cf marketplace -s SERVICE' to view descriptions of individual plans of a given service.
   ````
-  
+
 - Create a WSO2 API-M service instance using the following command:
- 
+
   ````bash
   $ cf create-service wso2-apim default wso2-apim
   Creating service instance wso2-apim in org pcfdev-org / space pcfdev-space as admin...
@@ -160,7 +160,7 @@ The quick start provides steps for installing WSO2 API Manager service broker on
   ````
 
 - Create an API definition JSON file with the following content:
-  
+
   ````json
   {
     "apiName": "HelloAPI",
@@ -250,7 +250,7 @@ The quick start provides steps for installing WSO2 API Manager service broker on
   ````
 
 - Stop the WSO2 API-M server using the following command:
-   
+
   ````bash
   cd $WSO2_APIM_HOME/bin
   ./wso2server.sh stop


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/pivotal-cf-apim/issues/38

## Goals
Add Open JDK support instead of Oracle JDK support
## Certification

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
cf version 6.40.1+85d04488a.2018-10-31
tile version 12.0.8
OS version Ubuntu 18.04
Deployed in PCF Ops Manager v2.3-build.170
