### PR TITLE
Fix API Manager Analytics misconfiguration for pattern-1

### DIFF
--- a/pattern-1/bosh-release/jobs/wso2apim/spec
+++ b/pattern-1/bosh-release/jobs/wso2apim/spec
@@ -79,25 +79,16 @@ properties:
   wso2apim.am_db.password:
     description: WSO2 APIM database password
 
-  wso2apim.mysql.stats_db:
-    description: wso2apim mysql statistics database name
-  wso2apim.mysql.event_store_db:
-    description: wso2apim mysql event store database name
-  wso2apim.mysql.processed_data_db:
-    description: wso2apim mysql analytics processed data database name
-  wso2apim.analytics.hostname:
-    description: wso2apim analytics hostname
+  wso2apim.apim_analytics_db.jdbc_url:
+    description: WSO2 APIM Analytics database JDBC URL
+  wso2apim.apim_analytics_db.driver:
+    description: WSO2 APIM Analytics database database driver name
+  wso2apim.apim_analytics_db.query:
+    description: WSO2 APIM Analytics database database validation query
+  wso2apim.apim_analytics_db.username:
+    description: WSO2 APIM Analytics database username
+  wso2apim.apim_analytics_db.password:
+    description: WSO2 APIM Analytics database password
 
   route_registrar.routes:
     description: routes registered for WSO2 APIM apps and gateway
-
-  cf.apps_domain:
-    description: Domain shared by the UAA and CF API eg 'bosh-lite.com'
-  cf.nats.host:
-    description: Hostname/IP of NATS
-  cf.nats.port:
-    description: Port that NATS listens on
-  cf.nats.username:
-    description: The user to use when authenticating with NATS
-  cf.nats.password:
-    description: The password to use when authenticating with NATS

--- a/pattern-1/bosh-release/jobs/wso2apim_analytics/spec
+++ b/pattern-1/bosh-release/jobs/wso2apim_analytics/spec
@@ -32,31 +32,13 @@ properties:
   wso2apim_analytics.address:
     description: wso2apim address
 
-  wso2apim.sp_cluster_db.jdbc_url:
+  wso2apim.apim_analytics_db.jdbc_url:
     description: WSO2 APIM Analytics database JDBC URL
-  wso2apim.sp_cluster_db.driver:
+  wso2apim.apim_analytics_db.driver:
     description: WSO2 APIM Analytics database database driver name
-  wso2apim.sp_cluster_db.query:
+  wso2apim.apim_analytics_db.query:
     description: WSO2 APIM Analytics database database validation query
-  wso2apim.sp_cluster_db.username:
+  wso2apim.apim_analytics_db.username:
     description: WSO2 APIM Analytics database username
-  wso2apim.sp_cluster_db.password:
+  wso2apim.apim_analytics_db.password:
     description: WSO2 APIM Analytics database password
-
-  wso2apim_analytics.mysql.stats_db:
-    description: wso2apim mysql statistics database name
-  wso2apim_analytics.mysql.event_store_db:
-    description: wso2apim mysql event store database name
-  wso2apim_analytics.mysql.processed_data_db:
-    description: wso2apim mysql analytics processed data database name
-
-  cf.apps_domain:
-    description: Domain shared by the UAA and CF API eg 'bosh-lite.com'
-  cf.nats.host:
-    description: Hostname/IP of NATS
-  cf.nats.port:
-    description: Port that NATS listens on
-  cf.nats.username:
-    description: The user to use when authenticating with NATS
-  cf.nats.password:
-    description: The password to use when authenticating with NATS

--- a/pattern-1/bosh-release/jobs/wso2apim_analytics/templates/config/deployment.yaml
+++ b/pattern-1/bosh-release/jobs/wso2apim_analytics/templates/config/deployment.yaml
@@ -414,13 +414,13 @@ wso2.datasources:
       definition:
         type: RDBMS
         configuration:
-          jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/worker/database/WSO2AM_STATS_DB;AUTO_SERVER=TRUE'
-          username: wso2carbon
-          password: wso2carbon
-          driverClassName: org.h2.Driver
+          jdbcUrl: <%= p("wso2apim.apim_analytics_db.jdbc_url") %>
+          username: <%= p("wso2apim.apim_analytics_db.username") %>
+          password: <%= p("wso2apim.apim_analytics_db.password") %>
+          driverClassName: <%= p("wso2apim.apim_analytics_db.driver") %>
           maxPoolSize: 50
           idleTimeout: 60000
-          connectionTestQuery: SELECT 1
+          connectionTestQuery: <%= p("wso2apim.apim_analytics_db.query") %>
           validationTimeout: 30000
           isAutoCommit: false
 
@@ -438,23 +438,6 @@ wso2.datasources:
           maxPoolSize: 50
           idleTimeout: 60000
           connectionTestQuery: SELECT 1
-          validationTimeout: 30000
-          isAutoCommit: false
-
-    - name: SP_CLUSTER_DB
-      description: "The datasource used for APIM MGW analytics data."
-      jndiConfig:
-        name: jdbc/SP_CLUSTER_DB
-      definition:
-        type: RDBMS
-        configuration:
-          jdbcUrl: <%= p("wso2apim.sp_cluster_db.jdbc_url") %>
-          username: <%= p("wso2apim.sp_cluster_db.username") %>
-          password: <%= p("wso2apim.sp_cluster_db.password") %>
-          driverClassName: <%= p("wso2apim.sp_cluster_db.driver") %>
-          maxPoolSize: 50
-          idleTimeout: 60000
-          connectionTestQuery: <%= p("wso2apim.sp_cluster_db.query") %>
           validationTimeout: 30000
           isAutoCommit: false
 
@@ -483,8 +466,8 @@ siddhi:
 
 # Cluster Configuration
 cluster.config:
-  enabled: true
-  groupId:  sp-worker
+  enabled: false
+  groupId:  sp
   coordinationStrategyClass: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
   strategyConfig:
     datasource: SP_CLUSTER_DB
@@ -492,22 +475,22 @@ cluster.config:
     heartbeatMaxRetry: 2
     eventPollingInterval: 1000
 
-# Sample of deployment.config for Two node HA
-deployment.config:
-  type: ha
-  eventSyncServer:
-    host: <%= spec.ip %>
-    port: 9893
-    advertisedHost: <%= spec.ip %>
-    advertisedPort: 9893
-    bossThreads: 10
-    workerThreads: 10
-  eventSyncClientPool:
-    maxActive: 10
-    maxTotal: 10
-    maxIdle: 10
-    maxWait: 60000
-    minEvictableIdleTimeMillis: 120000
+  # Sample of deployment.config for Two node HA
+#deployment.config:
+#  type: ha
+#  eventSyncServer:
+#    host: localhost
+#    port: 9893
+#    advertisedHost: localhost
+#    advertisedPort: 9893
+#    bossThreads: 10
+#    workerThreads: 10
+#  eventSyncClientPool:
+#    maxActive: 10
+#    maxTotal: 10
+#    maxIdle: 10
+#    maxWait: 60000
+#    minEvictableIdleTimeMillis: 120000
 
   # Sample of deployment.config for Distributed deployment
 #deployment.config:

--- a/pattern-1/tile/tile.yml
+++ b/pattern-1/tile/tile.yml
@@ -93,14 +93,14 @@ forms:
   - name: am_db_credentials
     label: AM DB Credentials
     type: simple_credentials
-- name: sp_cluster_db
+- name: apim_analytics_db
   label: AM Analytics Cluster DB connection information
-  description: WSO2 API Manager - Analytics Clustering Database connection information
+  description: WSO2 API Manager Analytics Database connection information
   properties:
-  - name: sp_db_jdbc_url
+  - name: analytics_db_jdbc_url
     type: string
     label: JDBC URL
-  - name: sp_db_driver
+  - name: analytics_db_driver
     type: dropdown_select
     label: Driver Class Name
     options:
@@ -109,10 +109,10 @@ forms:
       default: true
     - name: com.microsoft.sqlserver.jdbc.SQLServerDriver
       label: com.microsoft.sqlserver.jdbc.SQLServerDriver
-  - name: sp_db_query
+  - name: analytics_db_query
     type: string
     label: Validation Query
-  - name: sp_db_credentials
+  - name: analytics_db_credentials
     label: Cluster DB Credentials
     type: simple_credentials
 
@@ -153,12 +153,12 @@ packages:
     max_in_flight: 1
     properties:
       wso2apim:
-        sp_cluster_db:
-          jdbc_url: (( .properties.sp_db_jdbc_url.value ))
-          driver: (( .properties.sp_db_driver.value ))
-          query: (( .properties.sp_db_query.value ))
-          username: (( .properties.sp_db_credentials.identity ))
-          password: (( .properties.sp_db_credentials.password ))
+        apim_analytics_db:
+          jdbc_url: (( .properties.analytics_db_jdbc_url.value ))
+          driver: (( .properties.analytics_db_driver.value ))
+          query: (( .properties.analytics_db_query.value ))
+          username: (( .properties.analytics_db_credentials.identity ))
+          password: (( .properties.analytics_db_credentials.password ))
       route_registrar:
         routes:
           - name: wso2apim-analytics


### PR DESCRIPTION
## Purpose
Fix API Manager Analytics misconfiguration for pattern-1

## Goals
Get API usage data published to the API Manager dashboards.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
Ubuntu 18.04
PCF Ops Manager v2.4-build.131
tile version 12.0.8
bosh version 5.3.1-8366c6fd-2018-09-25T18:25:51Z
pcf version 12.0.8