### PR TITLE
Enable analytics for pattern-2

### DIFF
--- a/pattern-2/bosh-release/jobs/wso2apim_analytics/spec
+++ b/pattern-2/bosh-release/jobs/wso2apim_analytics/spec
@@ -47,23 +47,16 @@ properties:
   wso2apim.sp_cluster_db.password:
     description: WSO2 APIM Analytics database password
 
-  wso2apim_analytics.mysql.stats_db:
-    description: wso2apim mysql statistics database name
-  wso2apim_analytics.mysql.event_store_db:
-    description: wso2apim mysql event store database name
-  wso2apim_analytics.mysql.processed_data_db:
-    description: wso2apim mysql analytics processed data database name
+  wso2apim.persistence_db.jdbc_url:
+    description: WSO2 APIM persistence database JDBC URL
+  wso2apim.persistence_db.driver:
+    description: WSO2 APIM persistence database database driver name
+  wso2apim.persistence_db.query:
+    description: WSO2 APIM persistence database database validation query
+  wso2apim.persistence_db.username:
+    description: WSO2 APIM persistence database username
+  wso2apim.persistence_db.password:
+    description: WSO2 APIM persistence database password
 
   route_registrar.routes:
     description: routes registered for WSO2 APIM apps and gateway
-
-  cf.apps_domain:
-    description: Domain shared by the UAA and CF API eg 'bosh-lite.com'
-  cf.nats.host:
-    description: Hostname/IP of NATS
-  cf.nats.port:
-    description: Port that NATS listens on
-  cf.nats.username:
-    description: The user to use when authenticating with NATS
-  cf.nats.password:
-    description: The password to use when authenticating with NATS

--- a/pattern-2/bosh-release/jobs/wso2apim_analytics/templates/config/deployment.yaml
+++ b/pattern-2/bosh-release/jobs/wso2apim_analytics/templates/config/deployment.yaml
@@ -299,12 +299,13 @@ wso2.artifact.deployment:
 
   # Periodic Persistence Configuration
 state.persistence:
-  enabled: false
+  enabled: true
   intervalInMin: 1
   revisionsToKeep: 2
-  persistenceStore: org.wso2.carbon.stream.processor.core.persistence.FileSystemPersistenceStore
+  persistenceStore: org.wso2.carbon.stream.processor.core.persistence.DBPersistenceStore
   config:
-    location: siddhi-app-persistence
+    datasource: PERSISTENCE_DB   # A datasource with this name should be defined in wso2.datasources namespace
+    table: PERSISTENCE_TABLE
 
   # Secure Vault Configuration
 wso2.securevault:
@@ -441,10 +442,10 @@ wso2.datasources:
           validationTimeout: 30000
           isAutoCommit: false
 
-    - name: SP_CLUSTER_DB
+    - name: WSO2_CLUSTER_DB
       description: "The datasource used for APIM MGW analytics data."
       jndiConfig:
-        name: jdbc/SP_CLUSTER_DB
+        name: jdbc/WSO2_CLUSTER_DB
       definition:
         type: RDBMS
         configuration:
@@ -455,6 +456,23 @@ wso2.datasources:
           maxPoolSize: 50
           idleTimeout: 60000
           connectionTestQuery: <%= p("wso2apim.sp_cluster_db.query") %>
+          validationTimeout: 30000
+          isAutoCommit: false
+
+    - name: PERSISTENCE_DB
+      description: The MySQL datasource used for persistence
+      jndiConfig:
+        name: jdbc/PERSISTENCE_DB
+      definition:
+        type: RDBMS
+        configuration:
+          jdbcUrl: <%= p("wso2apim.persistence_db.jdbc_url") %>
+          username: <%= p("wso2apim.persistence_db.username") %>
+          password: <%= p("wso2apim.persistence_db.password") %>
+          driverClassName: <%= p("wso2apim.persistence_db.driver") %>
+          maxPoolSize: 50
+          idleTimeout: 60000
+          connectionTestQuery: SELECT 1
           validationTimeout: 30000
           isAutoCommit: false
 
@@ -487,7 +505,7 @@ cluster.config:
   groupId:  sp-worker
   coordinationStrategyClass: org.wso2.carbon.cluster.coordinator.rdbms.RDBMSCoordinationStrategy
   strategyConfig:
-    datasource: SP_CLUSTER_DB
+    datasource: WSO2_CLUSTER_DB
     heartbeatInterval: 1000
     heartbeatMaxRetry: 2
     eventPollingInterval: 1000

--- a/pattern-2/tile/tile.yml
+++ b/pattern-2/tile/tile.yml
@@ -115,6 +115,28 @@ forms:
   - name: sp_db_credentials
     label: Cluster DB Credentials
     type: simple_credentials
+- name: persistence_db
+  label: AM Analytics Persistence DB connection information
+  description: WSO2 API Manager - Persistence Database connection information
+  properties:
+  - name: persistence_db_jdbc_url
+    type: string
+    label: JDBC URL
+  - name: persistence_db_driver
+    type: dropdown_select
+    label: Driver Class Name
+    options:
+    - name: com.mysql.jdbc.Driver
+      label: com.mysql.jdbc.Driver
+      default: true
+    - name: com.microsoft.sqlserver.jdbc.SQLServerDriver
+      label: com.microsoft.sqlserver.jdbc.SQLServerDriver
+  - name: persistence_db_query
+    type: string
+    label: Validation Query
+  - name: persistence_db_credentials
+    label: Persistence DB Credentials
+    type: simple_credentials
 
 packages:
 - name: routing_release
@@ -159,6 +181,12 @@ packages:
           query: (( .properties.sp_db_query.value ))
           username: (( .properties.sp_db_credentials.identity ))
           password: (( .properties.sp_db_credentials.password ))
+        persistence_db:
+          jdbc_url: (( .properties.persistence_db_jdbc_url.value ))
+          driver: (( .properties.persistence_db_driver.value ))
+          query: (( .properties.persistence_db_query.value ))
+          username: (( .properties.persistence_db_credentials.identity ))
+          password: (( .properties.persistence_db_credentials.password ))
       route_registrar:
         routes:
           - name: wso2apim-analytics
@@ -167,7 +195,7 @@ packages:
             registration_interval: 20s
             uris:
               - wso2apim-analytics.(( ..cf.cloud_controller.system_domain.value ))
-          - name: wso2apim-analytics
+          - name: wso2apim-analytics-storeapi
             port: 9764
             tls_port: 7444
             registration_interval: 20s


### PR DESCRIPTION
## Purpose
Fix API Manager Analytics misconfiguration for pattern-2

## Goals
Get API usage data published to the API Manager dashboards.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
Ubuntu 18.04
PCF Ops Manager v2.4-build.131
tile version 12.0.8
bosh version 5.3.1-8366c6fd-2018-09-25T18:25:51Z
pcf version 12.0.8