### PR TITLE
Fix analytics issues in Pattern-2

### DIFF
--- a/pattern-2/bosh-release/jobs/wso2apim_analytics/spec
+++ b/pattern-2/bosh-release/jobs/wso2apim_analytics/spec
@@ -36,16 +36,27 @@ properties:
   wso2apim_analytics.address:
     description: wso2apim address
 
-  wso2apim.sp_cluster_db.jdbc_url:
+  wso2apim.analytics_db.jdbc_url:
     description: WSO2 APIM Analytics database JDBC URL
-  wso2apim.sp_cluster_db.driver:
+  wso2apim.analytics_db.driver:
     description: WSO2 APIM Analytics database database driver name
-  wso2apim.sp_cluster_db.query:
+  wso2apim.analytics_db.query:
     description: WSO2 APIM Analytics database database validation query
-  wso2apim.sp_cluster_db.username:
+  wso2apim.analytics_db.username:
     description: WSO2 APIM Analytics database username
-  wso2apim.sp_cluster_db.password:
+  wso2apim.analytics_db.password:
     description: WSO2 APIM Analytics database password
+
+  wso2apim.sp_cluster_db.jdbc_url:
+    description: WSO2 APIM Analytics cluster database JDBC URL
+  wso2apim.sp_cluster_db.driver:
+    description: WSO2 APIM Analytics cluster database database driver name
+  wso2apim.sp_cluster_db.query:
+    description: WSO2 APIM Analytics cluster database database validation query
+  wso2apim.sp_cluster_db.username:
+    description: WSO2 APIM Analytics cluster database username
+  wso2apim.sp_cluster_db.password:
+    description: WSO2 APIM Analytics cluster database password
 
   wso2apim.persistence_db.jdbc_url:
     description: WSO2 APIM persistence database JDBC URL

--- a/pattern-2/bosh-release/jobs/wso2apim_analytics/templates/config/deployment.yaml
+++ b/pattern-2/bosh-release/jobs/wso2apim_analytics/templates/config/deployment.yaml
@@ -415,13 +415,13 @@ wso2.datasources:
       definition:
         type: RDBMS
         configuration:
-          jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/worker/database/WSO2AM_STATS_DB;AUTO_SERVER=TRUE'
-          username: wso2carbon
-          password: wso2carbon
-          driverClassName: org.h2.Driver
+          jdbcUrl: <%= p("wso2apim.analytics_db.jdbc_url") %>
+          username: <%= p("wso2apim.analytics_db.username") %>
+          password: <%= p("wso2apim.analytics_db.password") %>
+          driverClassName: <%= p("wso2apim.analytics_db.driver") %>
           maxPoolSize: 50
           idleTimeout: 60000
-          connectionTestQuery: SELECT 1
+          connectionTestQuery: <%= p("wso2apim.analytics_db.query") %>
           validationTimeout: 30000
           isAutoCommit: false
 

--- a/pattern-2/tile/tile.yml
+++ b/pattern-2/tile/tile.yml
@@ -93,6 +93,28 @@ forms:
   - name: am_db_credentials
     label: AM DB Credentials
     type: simple_credentials
+- name: analytics_db
+  label: APIM Analytics DB connection information
+  description: WSO2 API Manager Analytics Database connection information
+  properties:
+  - name: analytics_db_jdbc_url
+    type: string
+    label: JDBC URL
+  - name: analytics_db_driver
+    type: dropdown_select
+    label: Driver Class Name
+    options:
+    - name: com.mysql.jdbc.Driver
+      label: com.mysql.jdbc.Driver
+      default: true
+    - name: com.microsoft.sqlserver.jdbc.SQLServerDriver
+      label: com.microsoft.sqlserver.jdbc.SQLServerDriver
+  - name: analytics_db_query
+    type: string
+    label: Validation Query
+  - name: analytics_db_credentials
+    label: AM Analytics DB Credentials
+    type: simple_credentials
 - name: sp_cluster_db
   label: AM Analytics Cluster DB connection information
   description: WSO2 API Manager - Analytics Clustering Database connection information
@@ -175,6 +197,12 @@ packages:
     max_in_flight: 1
     properties:
       wso2apim:
+        analytics_db:
+          jdbc_url: (( .properties.analytics_db_jdbc_url.value ))
+          driver: (( .properties.analytics_db_driver.value ))
+          query: (( .properties.analytics_db_query.value ))
+          username: (( .properties.analytics_db_credentials.identity ))
+          password: (( .properties.analytics_db_credentials.password ))
         sp_cluster_db:
           jdbc_url: (( .properties.sp_db_jdbc_url.value ))
           driver: (( .properties.sp_db_driver.value ))


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/pivotal-cf-apim/issues/70

## Goals
Fix the errors with analytics in the apim pattern-2 deployment.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
Ubuntu 18.04
PCF Ops Manager v2.4-build.131
tile version 12.0.8
bosh version 5.3.1-8366c6fd-2018-09-25T18:25:51Z
pcf version 12.0.8