### PR TITLE
[Pattern-2] Add Micro-gw analytics support

### DIFF
--- a/pattern-2/bosh-release/jobs/wso2apim_analytics/templates/config/deployment.yaml
+++ b/pattern-2/bosh-release/jobs/wso2apim_analytics/templates/config/deployment.yaml
@@ -432,13 +432,13 @@ wso2.datasources:
       definition:
         type: RDBMS
         configuration:
-          jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/worker/database/WSO2AM_MGW_ANALYTICS_DB;AUTO_SERVER=TRUE'
-          username: wso2carbon
-          password: wso2carbon
-          driverClassName: org.h2.Driver
+          jdbcUrl: <%= p("wso2apim.analytics_db.jdbc_url") %>
+          username: <%= p("wso2apim.analytics_db.username") %>
+          password: <%= p("wso2apim.analytics_db.password") %>
+          driverClassName: <%= p("wso2apim.analytics_db.driver") %>
           maxPoolSize: 50
           idleTimeout: 60000
-          connectionTestQuery: SELECT 1
+          connectionTestQuery: <%= p("wso2apim.analytics_db.query") %>
           validationTimeout: 30000
           isAutoCommit: false
 

--- a/pattern-2/tile/tile.yml
+++ b/pattern-2/tile/tile.yml
@@ -229,6 +229,15 @@ packages:
             router_group: wso2apim-analytics-storeapi
             external_port: 7444
             server_cert_domain_san: localhost
+          - name: wso2apim-analytics-http-transport
+            port: 9091
+            tls_port: 9444
+            registration_interval: 20s
+            uris:
+              - wso2apim-analytics-http-transport.(( ..cf.cloud_controller.system_domain.value ))
+            router_group: wso2apim-analytics-http-transport
+            external_port: 9444
+            server_cert_domain_san: localhost
   - name: keymanager
     instances: 2
     templates:


### PR DESCRIPTION
## Purpose
> Add support for Micro-gateway analytics
fixes #100 
fixes #99 

## Approach
> 
- Configure Micro-gateway analytics databases 
- Expose HTTPS port of Analytics nodes 

## Test environment
> 
Mac Mojave 10.14
PCF Ops Manager v2.4-build.131
tile version 12.0.8
bosh version 5.3.1-8366c6fd-2018-09-25T18:25:51Z
pcf version 12.0.8
 
