### PR TITLE
Reduce the default value of persistent disk size and other properties

### DIFF
--- a/pattern-2/tile/tile.yml
+++ b/pattern-2/tile/tile.yml
@@ -163,9 +163,9 @@ packages:
     templates:
     - name: nfs_server
       release: wso2am-release
-    memory: 4096
-    ephemeral_disk: 4096
-    persistent_disk: 16384
+    memory: 1024
+    ephemeral_disk: 1024
+    persistent_disk: 1024
     cpu: 2
     static_ip: 1
   - name: wso2apim_analytics
@@ -183,7 +183,7 @@ packages:
           deployment: (( ..cf.deployment_name ))
     memory: 4096
     ephemeral_disk: 4096
-    persistent_disk: 16384
+    persistent_disk: 1024
     cpu: 2
     static_ip: 1
     max_in_flight: 1
@@ -261,7 +261,7 @@ packages:
       description: Checks if Key Manager is up and running
     memory: 4096
     ephemeral_disk: 4096
-    persistent_disk: 16384
+    persistent_disk: 1024
     cpu: 2
     static_ip: 1
     max_in_flight: 1
@@ -321,7 +321,7 @@ packages:
       description: Checks if API Manager is up and running
     memory: 4096
     ephemeral_disk: 4096
-    persistent_disk: 16384
+    persistent_disk: 1024
     cpu: 2
     static_ip: 1
     max_in_flight: 1
@@ -381,7 +381,7 @@ packages:
       description: Checks if API Manager Gateway is up and running
     memory: 4096
     ephemeral_disk: 4096
-    persistent_disk: 16384
+    persistent_disk: 1024
     cpu: 2
     static_ip: 1
     max_in_flight: 1


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/pivotal-cf-apim/issues/102

## Goals
Reduce the default value of persistent disk size and other properties

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
Ubuntu 18.04
PCF Ops Manager v2.4-build.131
tile version 13.2.0
bosh version 5.5.1-7850ac98-2019-05-21T22:28:36Z
pcf version 13.2.0